### PR TITLE
Fix woob build in kmymoney 5.1.3 PR branch

### DIFF
--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -11,7 +11,7 @@
 # Needed for running tests:
 , qtbase, xvfb-run
 
-, python2, python3Packages
+, python3Packages
 }:
 
 stdenv.mkDerivation rec {
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-I${kitemmodels.dev}/include/KF5";
 
   nativeBuildInputs = [
-    doxygen extra-cmake-modules graphviz kdoctools python2
+    doxygen extra-cmake-modules graphviz kdoctools
     python3Packages.wrapPython wrapQtAppsHook autoPatchelfHook
   ];
 

--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -1,5 +1,6 @@
 { stdenv, lib, fetchurl, doxygen, extra-cmake-modules, graphviz, kdoctools
 , wrapQtAppsHook
+, autoPatchelfHook
 
 , akonadi, alkimia, aqbanking, gmp, gwenhywfar, kactivities, karchive
 , kcmutils, kcontacts, kdewebkit, kdiagram, kholidays, kidentitymanagement
@@ -27,7 +28,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     doxygen extra-cmake-modules graphviz kdoctools python2
-    python3Packages.wrapPython wrapQtAppsHook
+    python3Packages.wrapPython wrapQtAppsHook autoPatchelfHook
   ];
 
   buildInputs = [
@@ -61,6 +62,13 @@ stdenv.mkDerivation rec {
       xvfb-run -s '-screen 0 1024x768x24' make test \
         ARGS="-E '(reports-chart-test)'" # Test fails, so exclude it for now.
     '';
+
+  # libpython is required by the python interpreter embedded in kmymoney, so we
+  # need to explicitly tell autoPatchelf about it.
+  postFixup = ''
+    patchelf --debug --add-needed libpython3.10.so \
+      "$out/bin/.kmymoney-wrapped"
+  '';
 
   meta = {
     description = "Personal finance manager for KDE";


### PR DESCRIPTION
We needed some `patchelf` magic to fix the python interpreter embedded in `kmymoney`.